### PR TITLE
Replaces drop-down with admin bar list, fixes bug, provides format_code_lang method

### DIFF
--- a/wcm_lang_switch.php
+++ b/wcm_lang_switch.php
@@ -165,20 +165,15 @@ class UserLangSelect
 
 		$locale  = get_locale();
 
-		// For the labels (format_code_lang)
-		require_once( ABSPATH.'wp-admin/includes/ms.php' );
-		// Remove the update nag
-		add_action( 'admin_notices', array( $this, 'remove_notice' ), 0 );
-
 		$wp_admin_bar->add_menu( array(
 			 'id'    => 'user_lang_pick'
-			,'title' => format_code_lang($locale)
+			,'title' => $this->format_code_lang($locale)
 			,'href' =>'#'
 		) );
 
 		foreach ( $this->get_langs() as $lang )
 		{
-			$name = format_code_lang($lang);
+			$name = $this->format_code_lang($lang);
 			$link = add_query_arg(self :: $name, $lang );
 
 			if( $locale == $lang )
@@ -204,14 +199,34 @@ class UserLangSelect
 
 
 	/**
-	 * Remove the update nag for MS/MU installations, if in a single site setup
-	 * @since  0.3
-	 * @return void
-	 */
-	public function remove_notice()
+	 * Converts language code into 'human readable' form. 
+	 *
+	 * Is an exact copy of the function format_code_lang()
+	 * Including wp-admin/includes/ms.php in non-ms sites displays message prompting user to update network sites, hence we've just duplicated the function.
+	 *
+	 * @since  0.2
+	 * @link http://codex.wordpress.org/Function_Reference/format_code_lang 
+         *
+	 * @param string $code Language code, e.g. en_US or en
+	 * @return string The human readable language name, e.g. 'English'
+	*/
+	public function format_code_lang( $code = '' ) 
 	{
-		remove_action( current_filter(), __FUNCTION__ );
-		remove_action( current_filter(), 'site_admin_notice' );
+		$code = strtolower( substr( $code, 0, 2 ) );
+		$lang_codes = array(
+		'aa' => 'Afar', 'ab' => 'Abkhazian', 'af' => 'Afrikaans', 'ak' => 'Akan', 'sq' => 'Albanian', 'am' => 'Amharic', 'ar' => 'Arabic', 'an' => 'Aragonese', 'hy' => 'Armenian', 'as' => 'Assamese', 'av' => 'Avaric', 'ae' => 'Avestan', 'ay' => 'Aymara', 'az' => 'Azerbaijani', 'ba' => 'Bashkir', 'bm' => 'Bambara', 'eu' => 'Basque', 'be' => 'Belarusian', 'bn' => 'Bengali',
+		'bh' => 'Bihari', 'bi' => 'Bislama', 'bs' => 'Bosnian', 'br' => 'Breton', 'bg' => 'Bulgarian', 'my' => 'Burmese', 'ca' => 'Catalan; Valencian', 'ch' => 'Chamorro', 'ce' => 'Chechen', 'zh' => 'Chinese', 'cu' => 'Church Slavic; Old Slavonic; Church Slavonic; Old Bulgarian; Old Church Slavonic', 'cv' => 'Chuvash', 'kw' => 'Cornish', 'co' => 'Corsican', 'cr' => 'Cree',
+		'cs' => 'Czech', 'da' => 'Danish', 'dv' => 'Divehi; Dhivehi; Maldivian', 'nl' => 'Dutch; Flemish', 'dz' => 'Dzongkha', 'en' => 'English', 'eo' => 'Esperanto', 'et' => 'Estonian', 'ee' => 'Ewe', 'fo' => 'Faroese', 'fj' => 'Fijjian', 'fi' => 'Finnish', 'fr' => 'French', 'fy' => 'Western Frisian', 'ff' => 'Fulah', 'ka' => 'Georgian', 'de' => 'German', 'gd' => 'Gaelic; Scottish Gaelic',
+		'ga' => 'Irish', 'gl' => 'Galician', 'gv' => 'Manx', 'el' => 'Greek, Modern', 'gn' => 'Guarani', 'gu' => 'Gujarati', 'ht' => 'Haitian; Haitian Creole', 'ha' => 'Hausa', 'he' => 'Hebrew', 'hz' => 'Herero', 'hi' => 'Hindi', 'ho' => 'Hiri Motu', 'hu' => 'Hungarian', 'ig' => 'Igbo', 'is' => 'Icelandic', 'io' => 'Ido', 'ii' => 'Sichuan Yi', 'iu' => 'Inuktitut', 'ie' => 'Interlingue',
+		'ia' => 'Interlingua (International Auxiliary Language Association)', 'id' => 'Indonesian', 'ik' => 'Inupiaq', 'it' => 'Italian', 'jv' => 'Javanese', 'ja' => 'Japanese', 'kl' => 'Kalaallisut; Greenlandic', 'kn' => 'Kannada', 'ks' => 'Kashmiri', 'kr' => 'Kanuri', 'kk' => 'Kazakh', 'km' => 'Central Khmer', 'ki' => 'Kikuyu; Gikuyu', 'rw' => 'Kinyarwanda', 'ky' => 'Kirghiz; Kyrgyz',
+		'kv' => 'Komi', 'kg' => 'Kongo', 'ko' => 'Korean', 'kj' => 'Kuanyama; Kwanyama', 'ku' => 'Kurdish', 'lo' => 'Lao', 'la' => 'Latin', 'lv' => 'Latvian', 'li' => 'Limburgan; Limburger; Limburgish', 'ln' => 'Lingala', 'lt' => 'Lithuanian', 'lb' => 'Luxembourgish; Letzeburgesch', 'lu' => 'Luba-Katanga', 'lg' => 'Ganda', 'mk' => 'Macedonian', 'mh' => 'Marshallese', 'ml' => 'Malayalam',
+		'mi' => 'Maori', 'mr' => 'Marathi', 'ms' => 'Malay', 'mg' => 'Malagasy', 'mt' => 'Maltese', 'mo' => 'Moldavian', 'mn' => 'Mongolian', 'na' => 'Nauru', 'nv' => 'Navajo; Navaho', 'nr' => 'Ndebele, South; South Ndebele', 'nd' => 'Ndebele, North; North Ndebele', 'ng' => 'Ndonga', 'ne' => 'Nepali', 'nn' => 'Norwegian Nynorsk; Nynorsk, Norwegian', 'nb' => 'Bokmål, Norwegian, Norwegian Bokmål',
+		'no' => 'Norwegian', 'ny' => 'Chichewa; Chewa; Nyanja', 'oc' => 'Occitan, Provençal', 'oj' => 'Ojibwa', 'or' => 'Oriya', 'om' => 'Oromo', 'os' => 'Ossetian; Ossetic', 'pa' => 'Panjabi; Punjabi', 'fa' => 'Persian', 'pi' => 'Pali', 'pl' => 'Polish', 'pt' => 'Portuguese', 'ps' => 'Pushto', 'qu' => 'Quechua', 'rm' => 'Romansh', 'ro' => 'Romanian', 'rn' => 'Rundi', 'ru' => 'Russian',
+		'sg' => 'Sango', 'sa' => 'Sanskrit', 'sr' => 'Serbian', 'hr' => 'Croatian', 'si' => 'Sinhala; Sinhalese', 'sk' => 'Slovak', 'sl' => 'Slovenian', 'se' => 'Northern Sami', 'sm' => 'Samoan', 'sn' => 'Shona', 'sd' => 'Sindhi', 'so' => 'Somali', 'st' => 'Sotho, Southern', 'es' => 'Spanish; Castilian', 'sc' => 'Sardinian', 'ss' => 'Swati', 'su' => 'Sundanese', 'sw' => 'Swahili',
+		'sv' => 'Swedish', 'ty' => 'Tahitian', 'ta' => 'Tamil', 'tt' => 'Tatar', 'te' => 'Telugu', 'tg' => 'Tajik', 'tl' => 'Tagalog', 'th' => 'Thai', 'bo' => 'Tibetan', 'ti' => 'Tigrinya', 'to' => 'Tonga (Tonga Islands)', 'tn' => 'Tswana', 'ts' => 'Tsonga', 'tk' => 'Turkmen', 'tr' => 'Turkish', 'tw' => 'Twi', 'ug' => 'Uighur; Uyghur', 'uk' => 'Ukrainian', 'ur' => 'Urdu', 'uz' => 'Uzbek',
+		've' => 'Venda', 'vi' => 'Vietnamese', 'vo' => 'Volapük', 'cy' => 'Welsh','wa' => 'Walloon','wo' => 'Wolof', 'xh' => 'Xhosa', 'yi' => 'Yiddish', 'yo' => 'Yoruba', 'za' => 'Zhuang; Chuang', 'zu' => 'Zulu' );
+		$lang_codes = apply_filters( 'lang_codes', $lang_codes, $code );
+		return strtr( $code, $lang_codes );
 	}
 
 } // END Class UserLangSelect


### PR DESCRIPTION
Just three changes, sorry to group a bug fix with some feature changes, but I only noticed it after making some changes.
1. Replaces the drop-down menu with and sub-menu for the admin bar, I think this looks a lot nicer. The admin bar indicates which language is currently selected. As part of this, you have a link to the switch rather than posting a form (so no form, js or css is required).
2. The class needs to be initiated on `plugins_loaded` - otherwise it misses the `locale` hook. I noticed you added a callback on `locale` too - but this didn't seem to work. Maybe because `set_locale` was running too late, but then I'd expect it to take effect after another page load - but it didn't. Odd. Anyway `plugins_loaded` seems to early enough, but not so early that stuff like `wp_get_current_user()` is defined (can break some plug-ins if they trigger `locale` before  `wp_get_current_user()` is defined).
3. Removing the admin notice seemed a bit hacky, at least, I wasn't sure what would happen if the notice was _meant_ to be there. I've just copied the function in as a method. It's unlikely to need maintaining.
