### PR TITLE
more "correct" nativeName for Russian.

### DIFF
--- a/json/lang_native.json
+++ b/json/lang_native.json
@@ -529,7 +529,7 @@
 	},
 	"ru":{
 		"name":"Russian",
-		"nativeName":"русский язык"
+		"nativeName":"Русский"
 	},
 	"sa":{
 		"name":"Sanskrit (Saṁskṛta)",


### PR DESCRIPTION
I guess the same needs to be done for most (all?) of other nativeNames (i.e. a menu item normally starts with a capital letter and the language name rarely contains the word "language").
